### PR TITLE
fixup! QOL: add screenshotDirectory option for the screenshot dir, gets created automatically

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,9 +85,9 @@ void (async () => {
     }
     await wait(1000);
     await page.evaluate("alert(\"Speedrunnen klaar, screenshotten...\");");
-    
+
     const screenshotDir = config?.screenshotDirectory ?? "screenshots";
-    await mkdir(screenshotDir);
+    await mkdir(screenshotDir, { recursive: true });
     await page.screenshot({
         path: `${screenshotDir}/${Date.now()}.png`,
         type: "png"


### PR DESCRIPTION
Bug:
![image](https://github.com/25huizengek1/learnbeat-puppeteer/assets/51440893/36791a64-e2f5-4096-a06e-12941c96caf6)
As you can see, if the directory already exists, it errors out and doesn't make
a screenshot.
